### PR TITLE
Fix PYTHONPATH update when one's already set

### DIFF
--- a/impl/bin/cfx
+++ b/impl/bin/cfx
@@ -20,7 +20,7 @@ if 'PYTHONPATH' not in os.environ:
     os.environ['PYTHONPATH'] = python_lib_dir
 elif python_lib_dir not in os.environ['PYTHONPATH'].split(os.pathsep):
     paths = os.environ['PYTHONPATH'].split(os.pathsep)
-    paths.append(python_lib_dir)
+    paths.insert(0, python_lib_dir)
     os.environ['PYTHONPATH'] = os.pathsep.join(paths)
 
 import cuddlefish

--- a/impl/bin/cfx
+++ b/impl/bin/cfx
@@ -19,7 +19,9 @@ if python_lib_dir not in sys.path:
 if 'PYTHONPATH' not in os.environ:
     os.environ['PYTHONPATH'] = python_lib_dir
 elif python_lib_dir not in os.environ['PYTHONPATH'].split(os.pathsep):
-    os.environ['PYTHONPATH'] = os.environ['PYTHONPATH'].split(os.pathsep).append(python_lib_dir).join(os.pathsep)
+    paths = os.environ['PYTHONPATH'].split(os.pathsep)
+    paths.append(python_lib_dir)
+    os.environ['PYTHONPATH'] = os.pathsep.join(paths)
 
 import cuddlefish
 


### PR DESCRIPTION
Hi,

I tried to test chromeless on my computer, but running './run' as described in the doc didn't work, since it tries to update the PYTHONPATH to add the path of the project into, but the code couldn't work as it and it just crashed with the following exception:

```
$ ./run 
Will open the browser html =first_browser/index.html
You can also try other scripts such as ./run ui/thumbnails/index.html
Traceback (most recent call last):
  File "impl/bin/cfx", line 22, in <module>
    os.environ['PYTHONPATH'] = os.environ['PYTHONPATH'].split(os.pathsep).append(python_lib_dir).join(os.pathsep)
AttributeError: 'NoneType' object has no attribute 'join'
```

Thanks
