### PR TITLE
Fixed the mozfetched config that was missing a comma before the md5 definition. 

### DIFF
--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -25,7 +25,7 @@ software = {
         }
     },
     "Linux_32bit": {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-i686.tar.bz2"
+        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-i686.tar.bz2",
         "md5": "5acef7cc816691f5c8726731ee0d8bdf",
         "bin": {
             "path": "xulrunner/xulrunner",


### PR DESCRIPTION
I've fixed the mozfetched config that was missing a comma before the md5 definition on line 29 of **impl/mozfetcher/_config.py**

davids-macbook:chromeless david$ ./chromeless 
Traceback (most recent call last):
  File "./chromeless", line 80, in <module>
    import mozfetcher
  File "/users/david/dev/c/chromeless/impl/mozfetcher/**init**.py", line 1, in <module>
    from _fetcher import Fetcher
  File "/users/david/dev/c/chromeless/impl/mozfetcher/_fetcher.py", line 14, in <module>
    from . import _config
  File "/users/david/dev/c/chromeless/impl/mozfetcher/_config.py", line 29
    "md5": "5acef7cc816691f5c8726731ee0d8bdf",
