### PR TITLE
Monkey Patching anchor elements with `target='_top'`. Possible partial fix for #83.

### DIFF
--- a/modules/internal/chromeless-sandbox-window.js
+++ b/modules/internal/chromeless-sandbox-window.js
@@ -17,6 +17,12 @@ function isTopLevelWindow(w) {
   return false;
 }
 
+function removeTarget ( a ) {
+  if (a && a.target && a.removeAttribute) {
+      a.removeAttribute("target");
+  }
+}
+
 var checkWindows = function(subject, url) {
 
   if (subject.window.top != subject.window.self) {
@@ -64,6 +70,19 @@ var checkWindows = function(subject, url) {
           }
       }
   }
+  
+  // Monkey patching anchor elements to remove target='_top'.
+  subject.document.addEventListener("DOMNodeInserted", function( a ){ removeTarget( a.target ); }, false);
+  subject.document.addEventListener("DOMAttrModified", function( a ){ removeTarget( a.target ); }, false);
+  subject.document.addEventListener("DOMContentLoaded", function topAs() {
+      var as = subject.document.querySelectorAll("a[target=\"_top\"]"),
+          i = 0,
+          l = as.length;
+      for(;i<l;) {
+          removeTarget( as[i++] );
+      }
+      subject.document.removeEventListener("DOMContentLoaded", topAs, false);
+  }, false);
 };
 
 observers.add("content-document-global-created", checkWindows); 


### PR DESCRIPTION
I don't really like this method. But it kinda works.

Problems:
    - Might slow down heavy pages since we are now monitoring the crap out of our frames's DOM.
    - `target='_top'` in a nested iframe (e.g., `<iframe>Page with an iframe:<iframe>Nested Iframe</iframe></iframe>`) will NOT target its parent iframe, but itself instead.
    - Doesn't fix `_blank` or other `_` targets.
    - Its a hack; it sucks. This should be done at a higher level.

:-)
