### PR TITLE
Alleviate an annoyance caused by bug #91 by defaulting to use error pages

### DIFF
--- a/impl/appifier/resources/xulrunner.template/defaults/preferences/prefs.js
+++ b/impl/appifier/resources/xulrunner.template/defaults/preferences/prefs.js
@@ -9,6 +9,7 @@ pref("javascript.options.showInConsole", true);
 pref("extensions.logging.enabled", true);
 pref("nglayout.debug.disable_xul_fastload", true);
 pref("dom.report_all_js_exceptions", true);
+pref("browser.xul.error_pages.enabled", true);
 
 // This is here just because of the window.open issue -- see https://github.com/mozilla/chromeless/issues/43
 pref("browser.chromeURL", "chrome://chromeless/content/chromeless.xul");


### PR DESCRIPTION
Alleviate an annoyance caused by bug #91 by defaulting to use error pages instead of alerts.
