### PR TITLE
System-wide Chromeless installation

### DIFF
--- a/chromeless
+++ b/chromeless
@@ -78,7 +78,7 @@ if len(sys.argv) > 1:
         browserToLaunch = findBrowserHTML(sys.argv[1])
 
 if browserToLaunch == None:
-    browserToLaunch = findBrowserHTML("./examples/first_browser/index.html")
+    browserToLaunch = findBrowserHTML(os.path.join(cuddlefish_root, "examples", "first_browser", "index.html"))
 
 # throw an error message if we can't figure out what html file
 # is the browser's HTML entry point

--- a/chromeless
+++ b/chromeless
@@ -18,9 +18,13 @@ cuddlefish_root = os.path.dirname(os.path.abspath(sys.argv[0]))
 if 'CUDDLEFISH_ROOT' not in os.environ:
     os.environ['CUDDLEFISH_ROOT'] = cuddlefish_root
 
+# Set the "home directory" to store variable data and local configurations
+# independently for each system user.
+home_dir = os.path.expanduser("~/.chromeless")
+
 # set the "build directory", where we'll output built artifacts, download xulrunner,
 # etc.
-build_dir = os.path.join(cuddlefish_root, "build")
+build_dir = os.path.join(home_dir, "build")
 
 # add our own python-lib path to the python module search path.
 python_lib_dir = os.path.join(cuddlefish_root, "impl")

--- a/chromeless
+++ b/chromeless
@@ -9,7 +9,7 @@ import os,sys,shutil
 # the current chromeless version.  should be bumped when a release is tagged,
 # really we an immutable global accessible by all includes submodules, but
 # using the environment for this seems wonky.  ideas welcome.
-CHROMELESS_VERSION = "0.2";
+CHROMELESS_VERSION = "0.3";
 
 # set the cuddlefish "root directory" for this process if it's not already
 # set in the environment

--- a/chromeless.sh
+++ b/chromeless.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -efu
+
+CUDDLEFISH_ROOT="/usr/local/lib/chromeless"
+export CUDDLEFISH_ROOT
+
+"$CUDDLEFISH_ROOT/chromeless" "$@"

--- a/impl/appifier/_appifier.py
+++ b/impl/appifier/_appifier.py
@@ -6,6 +6,7 @@ import chromeless
 from string import Template
 import simplejson as json
 from _relpath import relpath
+from util import opencopy
 
 class Appifier(object):
     def __init__(self):
@@ -187,7 +188,7 @@ class Appifier(object):
         if verbose:
             print "  ... writing application info file"
 
-        with open(os.path.join(output_dir, "browser_code", "appinfo.json"), 'w') as f:
+        with opencopy(os.path.join(output_dir, "browser_code", "appinfo.json"), 'w') as f:
             f.write(json.dumps(app_info.object, indent=4))
 
         # now munge harness_options a bit to get correct path to browser_code in
@@ -202,7 +203,7 @@ class Appifier(object):
         if verbose:
             print "  ... writing harness options"
 
-        with open(os.path.join(output_dir, "harness-options.json"), 'w') as f:
+        with opencopy(os.path.join(output_dir, "harness-options.json"), 'w') as f:
             f.write(json.dumps(harness_options, indent=4))
 
         # XXX: support for extra packages located outside of the packages/ directory!

--- a/impl/appifier/resources/application.ini.template
+++ b/impl/appifier/resources/application.ini.template
@@ -7,8 +7,8 @@ Copyright=
 ID=${developer_email}
 
 [Gecko]
-MinVersion=2.0
-MaxVersion=2.0
+MinVersion=2.0.1
+MaxVersion=*
 
 [XRE]
 EnableExtensionManager=true

--- a/impl/chromeless/_dirs.py
+++ b/impl/chromeless/_dirs.py
@@ -3,5 +3,6 @@ import os
 class Dirs(object):
     def __init__(self):
         self.cuddlefish_root = os.environ['CUDDLEFISH_ROOT']
-        self.build_dir = os.path.join(self.cuddlefish_root, "build")
+        self.home_dir = os.path.expanduser("~/.chromeless")
+        self.build_dir = os.path.join(self.home_dir, "build")
         self.python_lib_dir = os.path.join(self.cuddlefish_root, "impl")

--- a/impl/cuddlefish/__init__.py
+++ b/impl/cuddlefish/__init__.py
@@ -271,7 +271,7 @@ def test_all_examples(env_root, defaults):
     fail = False
     for dirname in examples:
         print "Testing %s..." % dirname
-        output_test = os.path.join(env_root, "modules", "internal","test_harness","test-app.js")
+        output_test = os.path.join(chromeless.Dirs().home_dir, "modules", "internal", "test_harness", "test-app.js")
         try:
             import shutil
             from string import Template
@@ -288,6 +288,22 @@ def test_all_examples(env_root, defaults):
                with open(test_script_for_app, 'r') as f:
                   test_content = f.read()
                   prefix_contents = 'var options = { "staticArgs": {quitWhenDone: true, "browser": "'+defaultBrowser+'" , "appBasePath": "'+env_root+'" } };' + "\n"
+
+                  try:
+                          os.makedirs(os.path.dirname(output_test))
+                  except os.error:
+                          pass
+                  for f in os.listdir(os.path.join(env_root, "modules", "internal", "test_harness")):
+                          src = os.path.join(env_root, "modules", "internal", "test_harness", f)
+                          dst = os.path.join(os.path.dirname(output_test), os.path.basename(f))
+                          if os.path.exists(dst):
+                                  continue
+                          else:
+                                  print "%s does not exist" % dst
+                          if platform.system() != 'Windows':
+                                  os.symlink(src, dst)
+                          else:
+                                  shutil.copyfile(src, dst)
 
                   with open(output_test, 'w') as ff:
                      ff.write(prefix_contents)
@@ -461,7 +477,8 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
     if command == "test":
         harness_options['main'] = 'test_harness/run-tests'
         # XXX: we should write 'test-app' into a tempdir...
-        harness_options['testDir'] = os.path.join(chromeless.Dirs().cuddlefish_root, "modules", "internal", "test_harness")
+        # YYY: testDir is now under the home. Should we place it directly under tempdir?
+        harness_options['testDir'] = os.path.join(chromeless.Dirs().home_dir, "modules", "internal", "test_harness")
         resourceName = harness_guid + "-app-tests"
         resources[resourceName] = os.path.join(harness_options['testDir'])
         rootPaths.append("resource://" + resourceName + "/");

--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -1,5 +1,7 @@
+import os,chromeless
+
 software = {
-    "default": { "bin": { "path": "/usr/local/lib/chromeless/xulrunner" } }
+    "default": { "bin": { "path": os.path.join(chromeless.Dirs().cuddlefish_root, "xulrunner") } }
 }
 
 def getConfig(platform):

--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -32,6 +32,7 @@ software = {
             "sig": "d103f16afe6a6125bb28987a9e391fee"
         }
     }
+    "default": { "bin": { "path": "/usr/local/lib/chromeless/xulrunner" } }
 }
 
 def getConfig(platform):
@@ -41,4 +42,6 @@ def getConfig(platform):
                 return software[key]
         elif platform in key:
             return software[key]
+    if "default" in software:
+            return software["default"]
     raise RuntimeError("unsupported platform: " + platform)

--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -1,37 +1,4 @@
 software = {
-    "Linux_64bit": {
-       "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-x86_64.tar.bz2",
-       "md5": "cb0dc6ff5304b325098fc8910057884f",
-       "bin": {
-           "path": "xulrunner/xulrunner",
-           "sig": "d103f16afe6a6125bb28987a9e391fee"
-       }
-    },
-    # for both 32 and 64 bit darwin we'll use 32 bit binaries
-    ( "Darwin_64bit", "Darwin_32bit" ): {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/sdk/xulrunner-2.0.en-US.mac-i386.sdk.tar.bz2",
-        "md5": "cf56e216a05feed16cb290110fd89802",
-        "bin": {
-            "path": "xulrunner-sdk/bin/xulrunner-bin",
-            "sig": "ec043427ca789950bf388db3cf88c7cf"
-        }
-    },
-    ( "Windows_32bit", "Windows_64bit" ): {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.win32.zip",
-        "md5": "38e5c5ad08927278ed6c333aef836882",
-        "bin": {
-            "path": "xulrunner/xulrunner.exe",
-            "sig": "0910106650f397e67aa52f4c4d924f8e"
-        }
-    },
-    "Linux_32bit": {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-i686.tar.bz2",
-        "md5": "5acef7cc816691f5c8726731ee0d8bdf",
-        "bin": {
-            "path": "xulrunner/xulrunner",
-            "sig": "d103f16afe6a6125bb28987a9e391fee"
-        }
-    }
     "default": { "bin": { "path": "/usr/local/lib/chromeless/xulrunner" } }
 }
 

--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -1,6 +1,39 @@
 import os,chromeless
 
 software = {
+    "Linux_64bit": {
+       "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-x86_64.tar.bz2",
+       "md5": "cb0dc6ff5304b325098fc8910057884f",
+       "bin": {
+           "path": "xulrunner/xulrunner",
+           "sig": "d103f16afe6a6125bb28987a9e391fee"
+       }
+    },
+    # for both 32 and 64 bit darwin we'll use 32 bit binaries
+    ( "Darwin_64bit", "Darwin_32bit" ): {
+        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/sdk/xulrunner-2.0.en-US.mac-i386.sdk.tar.bz2",
+        "md5": "cf56e216a05feed16cb290110fd89802",
+        "bin": {
+            "path": "xulrunner-sdk/bin/xulrunner-bin",
+            "sig": "ec043427ca789950bf388db3cf88c7cf"
+        }
+    },
+    ( "Windows_32bit", "Windows_64bit" ): {
+        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.win32.zip",
+        "md5": "38e5c5ad08927278ed6c333aef836882",
+        "bin": {
+            "path": "xulrunner/xulrunner.exe",
+            "sig": "0910106650f397e67aa52f4c4d924f8e"
+        }
+    },
+    "Linux_32bit": {
+        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/2.0/runtimes/xulrunner-2.0.en-US.linux-i686.tar.bz2",
+        "md5": "5acef7cc816691f5c8726731ee0d8bdf",
+        "bin": {
+            "path": "xulrunner/xulrunner",
+            "sig": "d103f16afe6a6125bb28987a9e391fee"
+        }
+    }
     "default": { "bin": { "path": os.path.join(chromeless.Dirs().cuddlefish_root, "xulrunner") } }
 }
 

--- a/impl/mozfetcher/_fetcher.py
+++ b/impl/mozfetcher/_fetcher.py
@@ -55,7 +55,7 @@ class Fetcher(object):
 
     def _check_build_dir(self, buildDir):
         if not os.path.isdir(buildDir):
-            os.mkdir(buildDir)
+            os.makedirs(buildDir)
         return
 
     def _print(self, descriptor, string):

--- a/impl/mozfetcher/_fetcher.py
+++ b/impl/mozfetcher/_fetcher.py
@@ -45,12 +45,16 @@ class Fetcher(object):
             return 'error'
 
     def needs_fetch(self):
-        want = self._config["bin"]["sig"]
+        try:
+            want = self._config["bin"]["sig"]
+        except KeyError:
+            want = False
         path = os.path.join(self._buildDir, self._config["bin"]["path"])
         if os.path.exists(path) and not want:
             print 'No bin/sig setting for %s' % path
             print 'Hash:'
             print '  %s' % self._calc_md5(path)
+            return False
         return not self._md5_match(path, want)
 
     def _check_build_dir(self, buildDir):

--- a/impl/util/__init__.py
+++ b/impl/util/__init__.py
@@ -1,0 +1,1 @@
+from misc import opencopy

--- a/impl/util/misc.py
+++ b/impl/util/misc.py
@@ -1,0 +1,17 @@
+import os, errno
+import shutil
+
+def opencopy(path, mode):
+        try:
+                return open(path, mode)
+        except IOError as (ecode, estr):
+                if ecode == errno.EACCES and \
+                   mode == 'w' and \
+                   os.path.islink(path):
+                           target = os.path.realpath(path)
+                           print 'Make a copy of the read-only file %s' % target
+                           os.unlink(path)
+                           shutil.copyfile(target, path)
+                           return open(path, mode)
+                else:
+                        raise

--- a/run-mozilla.sh
+++ b/run-mozilla.sh
@@ -1,0 +1,400 @@
+#!/bin/sh
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is mozilla.org code.
+#
+# The Initial Developer of the Original Code is
+# Netscape Communications Corporation.
+# Portions created by the Initial Developer are Copyright (C) 1998
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+cmdname=`basename "$0"`
+MOZ_DIST_BIN=`dirname "$0"`
+MOZ_DEFAULT_NAME="./${cmdname}-bin"
+MOZ_APPRUNNER_NAME="./mozilla-bin"
+MOZ_PROGRAM=""
+
+exitcode=1
+#
+##
+## Functions
+##
+##########################################################################
+moz_usage()
+{
+echo "Usage:  ${cmdname} [options] [program]"
+echo ""
+echo "  options:"
+echo ""
+echo "    -g                   Run in debugger."
+echo "    --debug"
+echo ""
+echo "    -d debugger          Debugger to use."
+echo "    --debugger debugger"
+echo ""
+echo "    -a debugger_args     Arguments passed to [debugger]."
+echo "    --debugger-args debugger_args"
+echo ""
+echo "  Examples:"
+echo ""
+echo "  Run the mozilla-bin binary"
+echo ""
+echo "    ${cmdname} mozilla-bin"
+echo ""
+echo "  Debug the mozilla-bin binary in gdb"
+echo ""
+echo "    ${cmdname} -g mozilla-bin -d gdb"
+echo ""
+echo "  Run mozilla-bin under valgrind with arguments"
+echo ""
+echo "    ${cmdname} -g -d valgrind -a '--tool=memcheck --leak-check=full' mozilla-bin"
+echo ""
+	return 0
+}
+##########################################################################
+moz_bail()
+{
+	message=$1
+	echo
+	echo "$cmdname: $message"
+	echo
+	exit 1
+}
+##########################################################################
+moz_test_binary()
+{
+	binary=$1
+	if [ -f "$binary" ]
+	then
+		if [ -x "$binary" ]
+		then
+			return 1
+		fi
+	fi
+	return 0
+}
+##########################################################################
+moz_get_debugger()
+{
+	debuggers="ddd gdb dbx bdb native-gdb"
+	debugger="notfound"
+	done="no"
+	for d in $debuggers
+	do
+		moz_test_binary /bin/which
+		if [ $? -eq 1 ]
+		then
+			dpath=`which ${d}`	
+		else 	
+			dpath=`LC_MESSAGES=C type ${d} | awk '{print $3;}' | sed -e 's/\.$//'`	
+		fi
+		if [ -x "$dpath" ]
+		then
+			debugger=$dpath
+			break
+		fi
+	done
+	echo $debugger
+	return 0
+}
+##########################################################################
+moz_run_program()
+{
+	prog=$MOZ_PROGRAM
+	##
+	## Make sure the program is executable
+	##
+	if [ ! -x "$prog" ]
+	then
+		moz_bail "Cannot execute $prog."
+	fi
+	##
+	## Run the program
+	##
+	exec "$prog" ${1+"$@"}
+	exitcode=$?
+}
+##########################################################################
+moz_debug_program()
+{
+	prog=$MOZ_PROGRAM
+	##
+	## Make sure the program is executable
+	##
+	if [ ! -x "$prog" ]
+	then
+		moz_bail "Cannot execute $prog."
+	fi
+	if [ -n "$moz_debugger" ]
+	then
+		moz_test_binary /bin/which
+		if [ $? -eq 1 ]
+		then	
+			debugger=`which $moz_debugger` 
+		else
+			debugger=`LC_MESSAGES=C type $moz_debugger | awk '{print $3;}' | sed -e 's/\.$//'` 
+		fi	
+	else
+		debugger=`moz_get_debugger`
+	fi
+    if [ -x "$debugger" ] 
+    then
+# If you are not using ddd, gdb and know of a way to convey the arguments 
+# over to the prog then add that here- Gagan Saksena 03/15/00
+        case `basename $debugger` in
+            native-gdb) echo "$debugger $moz_debugger_args --args $prog" ${1+"$@"}
+                exec "$debugger" $moz_debugger_args --args "$prog" ${1+"$@"}
+                exitcode=$?
+                ;;
+            gdb) echo "$debugger $moz_debugger_args --args $prog" ${1+"$@"}
+                exec "$debugger" $moz_debugger_args --args "$prog" ${1+"$@"}
+		exitcode=$?
+                ;;
+            ddd) echo "$debugger $moz_debugger_args --gdb -- --args $prog" ${1+"$@"}
+		exec "$debugger" $moz_debugger_args --gdb -- --args "$prog" ${1+"$@"}
+		exitcode=$?
+                ;;
+            *) echo "$debugger $moz_debugger_args $prog ${1+"$@"}"
+                exec $debugger $moz_debugger_args "$prog" ${1+"$@"}
+		exitcode=$?
+                ;;
+        esac
+    else
+        moz_bail "Could not find a debugger on your system."
+    fi
+}
+##########################################################################
+##
+## Command line arg defaults
+##
+moz_debug=0
+moz_debugger=""
+moz_debugger_args=""
+#
+##
+## Parse the command line
+##
+while [ $# -gt 0 ]
+do
+  case $1 in
+    -g | --debug)
+      moz_debug=1
+      shift
+      ;;
+    -d | --debugger)
+      moz_debugger=$2;
+      if [ "${moz_debugger}" != "" ]; then
+	shift 2
+      else
+        echo "-d requires an argument"
+        exit 1
+      fi
+      ;;
+    -a | --debugger-args)
+      moz_debugger_args=$2;
+      if [ "${moz_debugger_args}" != "" ]; then
+	shift 2
+      else
+        echo "-a requires an argument"
+        exit 1
+      fi
+      ;;
+    *)
+      break;
+      ;;
+  esac
+done
+#
+##
+## Program name given in $1
+##
+if [ $# -gt 0 ]
+then
+	MOZ_PROGRAM=$1
+	shift
+fi
+##
+## Program not given, try to guess a default
+##
+if [ -z "$MOZ_PROGRAM" ]
+then
+	##
+	## Try this script's name with '-bin' appended
+	##
+	if [ -x "$MOZ_DEFAULT_NAME" ]
+	then
+		MOZ_PROGRAM=$MOZ_DEFAULT_NAME
+	##
+	## Try mozilla-bin
+	## 
+	elif [ -x "$MOZ_APPRUNNER_NAME" ]
+	then
+		MOZ_PROGRAM=$MOZ_APPRUNNER_NAME
+	fi
+fi
+#
+#
+##
+## Make sure the program is executable
+##
+if [ ! -x "$MOZ_PROGRAM" ]
+then
+	moz_bail "Cannot execute $MOZ_PROGRAM."
+fi
+#
+##
+## Set MOZILLA_FIVE_HOME
+##
+MOZILLA_FIVE_HOME=$MOZ_DIST_BIN
+
+if [ -z "$MRE_HOME" ]; then
+    MRE_HOME=$MOZILLA_FIVE_HOME
+fi
+##
+## Set LD_LIBRARY_PATH
+##
+## On Solaris we use $ORIGIN (set in RUNPATH) instead of LD_LIBRARY_PATH 
+## to locate shared libraries. 
+##
+## When a shared library is a symbolic link, $ORIGIN will be replaced with
+## the real path (i.e., what the symbolic link points to) by the runtime
+## linker.  For example, if dist/bin/libxul.so is a symbolic link to
+## toolkit/library/libxul.so, $ORIGIN will be "toolkit/library" instead of "dist/bin".
+## So the runtime linker will use "toolkit/library" NOT "dist/bin" to locate the
+## other shared libraries that libxul.so depends on.  This only happens
+## when a user (developer) tries to start firefox, thunderbird, or seamonkey
+## under dist/bin. To solve the problem, we should rely on LD_LIBRARY_PATH
+## to locate shared libraries.
+##
+## Note: 
+##  We test $MOZ_DIST_BIN/*.so. If any of them is a symbolic link,
+##  we need to set LD_LIBRARY_PATH.
+##########################################################################
+moz_should_set_ld_library_path()
+{
+	[ `uname -s` != "SunOS" ] && return 0
+	for sharedlib in $MOZ_DIST_BIN/*.so
+	do
+		[ -h $sharedlib ] && return 0
+	done
+	return 1
+}
+if moz_should_set_ld_library_path
+then
+	LD_LIBRARY_PATH=${MOZ_DIST_BIN}:${MOZ_DIST_BIN}/plugins:${MRE_HOME}${LD_LIBRARY_PATH:+":$LD_LIBRARY_PATH"}
+fi 
+
+if [ -n "$LD_LIBRARYN32_PATH" ]
+then
+	LD_LIBRARYN32_PATH=${MOZ_DIST_BIN}:${MOZ_DIST_BIN}/plugins:${MRE_HOME}${LD_LIBRARYN32_PATH:+":$LD_LIBRARYN32_PATH"}
+fi
+if [ -n "$LD_LIBRARYN64_PATH" ]
+then
+	LD_LIBRARYN64_PATH=${MOZ_DIST_BIN}:${MOZ_DIST_BIN}/plugins:${MRE_HOME}${LD_LIBRARYN64_PATH:+":$LD_LIBRARYN64_PATH"}
+fi
+if [ -n "$LD_LIBRARY_PATH_64" ]; then
+	LD_LIBRARY_PATH_64=${MOZ_DIST_BIN}:${MOZ_DIST_BIN}/plugins:${MRE_HOME}${LD_LIBRARY_PATH_64:+":$LD_LIBRARY_PATH_64"}
+fi
+#
+#
+## Set SHLIB_PATH for HPUX
+SHLIB_PATH=${MOZ_DIST_BIN}:${MRE_HOME}${SHLIB_PATH:+":$SHLIB_PATH"}
+#
+## Set LIBPATH for AIX
+LIBPATH=${MOZ_DIST_BIN}:${MRE_HOME}${LIBPATH:+":$LIBPATH"}
+#
+## Set DYLD_LIBRARY_PATH for Mac OS X (Darwin)
+DYLD_LIBRARY_PATH=${MOZ_DIST_BIN}:${MRE_HOME}${DYLD_LIBRARY_PATH:+":$DYLD_LIBRARY_PATH"}
+#
+## Set LIBRARY_PATH for BeOS
+LIBRARY_PATH=${MOZ_DIST_BIN}:${MOZ_DIST_BIN}/components:${MRE_HOME}${LIBRARY_PATH:+":$LIBRARY_PATH"}
+#
+## Set ADDON_PATH for BeOS
+ADDON_PATH=${MOZ_DIST_BIN}${ADDON_PATH:+":$ADDON_PATH"}
+#
+## Solaris Xserver(Xsun) tuning - use shared memory transport if available
+if [ "$XSUNTRANSPORT" = "" ]
+then 
+        XSUNTRANSPORT="shmem" 
+        XSUNSMESIZE="512"
+        export XSUNTRANSPORT XSUNSMESIZE
+fi
+
+# Disable Gnome crash dialog
+GNOME_DISABLE_CRASH_DIALOG=1
+export GNOME_DISABLE_CRASH_DIALOG
+
+if [ "$moz_debug" -eq 1 ]
+then
+  echo "MOZILLA_FIVE_HOME=$MOZILLA_FIVE_HOME"
+  echo "  LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+  if [ -n "$LD_LIBRARYN32_PATH" ]
+  then
+  	echo "LD_LIBRARYN32_PATH=$LD_LIBRARYN32_PATH"
+  fi
+  if [ -n "$LD_LIBRARYN64_PATH" ]
+  then
+  	echo "LD_LIBRARYN64_PATH=$LD_LIBRARYN64_PATH"
+  fi
+  if [ -n "$LD_LIBRARY_PATH_64" ]; then
+  	echo "LD_LIBRARY_PATH_64=$LD_LIBRARY_PATH_64"
+  fi
+  if [ -n "$DISPLAY" ]; then
+       echo "DISPLAY=$DISPLAY"
+  fi
+  if [ -n "$FONTCONFIG_PATH" ]; then
+	echo "FONTCONFIG_PATH=$FONTCONFIG_PATH"
+  fi
+  if [ -n "$MOZILLA_POSTSCRIPT_PRINTER_LIST" ]; then
+       echo "MOZILLA_POSTSCRIPT_PRINTER_LIST=$MOZILLA_POSTSCRIPT_PRINTER_LIST"
+  fi
+  echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
+  echo "     LIBRARY_PATH=$LIBRARY_PATH"
+  echo "       SHLIB_PATH=$SHLIB_PATH"
+  echo "          LIBPATH=$LIBPATH"
+  echo "       ADDON_PATH=$ADDON_PATH"
+  echo "      MOZ_PROGRAM=$MOZ_PROGRAM"
+  echo "      MOZ_TOOLKIT=$MOZ_TOOLKIT"
+  echo "        moz_debug=$moz_debug"
+  echo "     moz_debugger=$moz_debugger"
+  echo "moz_debugger_args=$moz_debugger_args"
+fi
+#
+export MOZILLA_FIVE_HOME LD_LIBRARY_PATH
+export SHLIB_PATH LIBPATH LIBRARY_PATH ADDON_PATH DYLD_LIBRARY_PATH
+
+if [ $moz_debug -eq 1 ]
+then
+	moz_debug_program ${1+"$@"}
+else
+	moz_run_program ${1+"$@"}
+fi
+
+exit $exitcode


### PR DESCRIPTION
  Hi!

  I'm working on the system-wide installation of Chromeless and it's RPM package for ALT Linux distributions.

  One direction of activity is to use the system-wide available xulrunner (branch 'use-sys-xulrunner'). In accordance with the policy, the users of a distribution should not download and install non-packaged software. However, the desired version of the xulrunner can be required via the package dependency mechanism. I found that the xulrunner 2.0.1 is the minimal version that runs chromeless properly and modify the application.ini.template accordingly.

  Now, if the mozfetcher fails to find a suitable xulrunner configuration for the current platform, it tries to use the special "default" entry of the 'software' dictionary. That entry, if exists, should point to the system xulrunner installation and thus is not required to have a signature: the security and version issues are handled by the package subsystem. In fact, I decided not to require signatures for all of the dictionary entries, meaning that all users who would edit the _config.py know what they are doing. The "path" value of the "default" entry is a subject to be configured for a particular distribution. However, later I realized that it is more naturally to have the path to be calculated relatively to the cuddlefish root (see below).

  The other, larger direction of activity is to develop an effective and portable system layout for the chromeless files (branch 'sys-layout'). More details follow.

  The first thing I encountered was that chromeless is unable to run applications supplied in RO mode: some of the files in the application runtime directory (i.e. build/appname) are linked to the original files, yet attempts are made to modify them. If the original file is accessible in RO mode only, then an I/O error occurs. I added the code converting links to copies on the fly if the attempt to open the file in RW mode fails.

  Then I modified _dirs.py in order to place the 'build' directory in the user's home directory under the ~/.chromeless. With a system-wide available 'chromeless' command it seems strange to make a 'build' subdirectory in every current directory that come, doesn't it?

  The test outputs are now written under the ~/.chromeless too.

  In order to run the chromeless script with the CUDDLEFISH_ROOT environment variable set to a proper value I've added the wrapper shell script. The variable is set to the default value if it doesn't have a value yet. That default value is the neutral '/usr/local/lib/chromeless' and is subject to be substituted for a particular distribution.

  Taken the cuddlefish root as the only reference point, I then tended to adapt the chromeless code to search for all of the files from that root. First, I modifyed the chromless Python script itself to look for the default example ('first_browser' application) in the cuddlefish root directory. Then I added the 'run-mozilla.sh' to be installed in the cuddlefish root and modified mozfetcher, configuring the default xulrunner to be located in that directory too. Now, it is enough to place the links to the proper 'xulrunner' and 'xulrunner-bin' files in the cuddlefish root directory to make the chromeless be run by any user of the system.

  The resulting file layout can be found in the chromeless-*.rpm packages in the Sisyphus repository: http://packages.altlinux.org/en/Sisyphus/srpms/chromeless/get . The layout is tested and seems to work.

  I've merged the branches into the master trying to keep the original behavior of a locally run ./chromeless. It seems to run in that manner too.

```
See you in the `git log`!

  Paul.
```
