### PR TITLE
fix download links: releases.mozilla.org -> ftp.mozilla.org

### DIFF
--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -1,6 +1,6 @@
 software = {
     "Linux_64bit": {
-       "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.linux-x86_64.tar.bz2",
+       "url": "http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.linux-x86_64.tar.bz2",
        "md5": "a1e98013cbb4d9685461465e09b3c7c7",
        "bin": {
            "path": "xulrunner/xulrunner",
@@ -9,7 +9,7 @@ software = {
     },
     # for both 32 and 64 bit darwin we'll use 32 bit binaries
     ( "Darwin_64bit", "Darwin_32bit" ): {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/sdk/xulrunner-6.0.2.en-US.mac-i386.sdk.tar.bz2",
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/sdk/xulrunner-6.0.2.en-US.mac-i386.sdk.tar.bz2",
         "md5": "a645c56fb9f3dacc8e7f96166bfb288d",
         "bin": {
             "path": "xulrunner-sdk/bin/xulrunner-bin",
@@ -17,7 +17,7 @@ software = {
         }
     },
     ( "Windows_32bit", "Windows_64bit" ): {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.win32.zip",
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.win32.zip",
         "md5": "173502a8f48d8eb74baa9c7326d91733",
         "bin": {
             "path": "xulrunner/xulrunner.exe",
@@ -25,7 +25,7 @@ software = {
         }
     },
     "Linux_32bit": {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.linux-i686.tar.bz2",
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.linux-i686.tar.bz2",
         "md5": "b348164d69ab9d1b226e98a4893029f2",
         "bin": {
             "path": "xulrunner/xulrunner",


### PR DESCRIPTION
The download links in chromeless have been broken for a while, as releases.mozilla.org does not host xulrunner any more. This commit changes the download urls to ftp.mozilla.org.
