### PR TITLE
Update URL for xulrunner 6.0.2 on windows to make it work.

### DIFF
--- a/impl/mozfetcher/_config.py
+++ b/impl/mozfetcher/_config.py
@@ -17,7 +17,7 @@ software = {
         }
     },
     ( "Windows_32bit", "Windows_64bit" ): {
-        "url": "http://releases.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.win32.zip",
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.win32.zip",
         "md5": "173502a8f48d8eb74baa9c7326d91733",
         "bin": {
             "path": "xulrunner/xulrunner.exe",


### PR DESCRIPTION
The xulrunner release for windows is at http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/6.0.2/runtimes/xulrunner-6.0.2.en-US.win32.zip

I couldn't get through the example in the documentation because chromeless kept trying to get the xulrunner from a location where it does not exist. After changing the URL, the xulrunner package could be fetched and the example ran.
